### PR TITLE
Fix uncountRepost

### DIFF
--- a/discord-bot/api/emojis.js
+++ b/discord-bot/api/emojis.js
@@ -70,14 +70,15 @@ export const countRepost = async (userid, msgid, accuserid) => {
 
 /**
  * Withdraw a repost accusation. POST /api/message-processing/count-repost (repost: -1)
+ * @param {string} userid - Message author (accused)
  * @param {string} msgid - Message ID
  * @param {string} accuserid - User who is removing their repost reaction
  */
-export const uncountRepost = async (msgid, accuserid) => {
-  if (!msgid || !accuserid) return;
+export const uncountRepost = async (userid, msgid, accuserid) => {
+  if (!msgid || !userid || !accuserid) return;
   await api.post("/api/message-processing/count-repost", {
     app: "discord",
-    userid: "0",
+    userid,
     msgid,
     accuser: accuserid,
     repost: -1,

--- a/discord-bot/events/messages/utilities/reactionHandler.js
+++ b/discord-bot/events/messages/utilities/reactionHandler.js
@@ -85,7 +85,7 @@ export async function handleReactionRemove(reaction, user, options) {
     : reaction.message;
 
   if (reaction._emoji.id === repostEmojiId) {
-    uncountRepost(message.id, user.id);
+    uncountRepost(message.author.id, message.id, user.id);
   }
 
   if (


### PR DESCRIPTION
wasn't sending userID for some reason, and the same endpoint is used for count/uncount. And it expects a userID